### PR TITLE
Adds a test for anonymous bind

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -79,5 +79,6 @@
         <env name="TESTS_ZEND_LDAP_ALT_DN" value="uid=user1,dc=example,dc=com" />
         <env name="TESTS_ZEND_LDAP_ALT_PASSWORD" value="user1" />
         <env name="TESTS_ZEND_LDAP_WRITEABLE_SUBTREE" value="ou=test,dc=example,dc=com" />
+        <env name="TESTS_ZEND_LDAP_ANONYMOUS_BIND_ALLOWED" value="true"/>
     </php>
 </phpunit>

--- a/test/BindTest.php
+++ b/test/BindTest.php
@@ -185,6 +185,10 @@ class BindTest extends \PHPUnit_Framework_TestCase
         } catch (Exception\LdapException $zle) {
             /* Note that if your server actually allows anonymous binds this test will fail.
              */
+            if (getenv('TESTS_ZEND_LDAP_ANONYMOUS_BIND_ALLOWED')) {
+                $this->markTestSkipped('Anonymous bind needs to be disallowed for this test');
+            }
+
             $this->assertContains('Failed to retrieve DN', $zle->getMessage());
         }
     }


### PR DESCRIPTION
The test will fail if anonymous bind is allowed. But as some other
tests need anonymous bind either they fail or this one fails. Therefore
encapsulating one failing test was easier.

This should be merged after PR #8 