### PR TITLE
Adds ldap-module to Travis build-env

### DIFF
--- a/.ci/php.ini
+++ b/.ci/php.ini
@@ -1,0 +1,1 @@
+extension=ldap.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ notifications:
   irc: "irc.freenode.org#zftalk.dev"
   email: false
 
+before_script:
+  - phpenv config-add .ci/php.ini || return 0
+
 before_install:
   - if [[ $EXECUTE_TEST_COVERALLS != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
   - composer self-update


### PR DESCRIPTION
This PR adds PHPs ldap-extension to the build-environment created by
Travis. Without this change an automates travis build can not use the
LDAP-functions inside PHP as ext/ldap is not available.