### PR TITLE
Removes ldap_sort while preserving sorting

### DIFF
--- a/src/Collection/DefaultIterator.php
+++ b/src/Collection/DefaultIterator.php
@@ -61,6 +61,27 @@ class DefaultIterator implements Iterator, Countable
     protected $attributeNameTreatment = self::ATTRIBUTE_TO_LOWER;
 
     /**
+     * This array holds a list of resources and sorting-values.
+     *
+     * Each result is represented by an array containing the keys <var>resource</var>
+     * which holds a resource of a result-item and the key <var>sortValue</var>
+     * which holds the value by which the array will be sorted.
+     *
+     * The resources will be filled on creating the instance and the sorting values
+     * on sorting.
+     *
+     * @var array
+     */
+    protected $entries = [];
+
+    /**
+     * The function to sort the entries by
+     *
+     * @var callable
+     */
+    protected $sortFunction;
+
+    /**
      * Constructor.
      *
      * @param  \Zend\Ldap\Ldap $ldap
@@ -70,6 +91,7 @@ class DefaultIterator implements Iterator, Countable
      */
     public function __construct(Ldap\Ldap $ldap, $resultId)
     {
+        $this->setSortFunction('strnatcasecmp');
         $this->ldap      = $ldap;
         $this->resultId  = $resultId;
 
@@ -79,6 +101,23 @@ class DefaultIterator implements Iterator, Countable
         ErrorHandler::stop();
         if ($this->itemCount === false) {
             throw new Exception\LdapException($this->ldap, 'counting entries');
+        }
+
+        $identifier = ldap_first_entry(
+            $ldap->getResource(),
+            $resultId
+        );
+
+        while (false !== $identifier) {
+            $this->entries[] = [
+                'resource' => $identifier,
+                'sortValue' => '',
+            ];
+
+            $identifier = ldap_next_entry(
+                $ldap->getResource(),
+                $identifier
+            );
         }
     }
 
@@ -276,53 +315,30 @@ class DefaultIterator implements Iterator, Countable
 
     /**
      * Move forward to next result item
-     * Implements Iterator
      *
-     * @throws \Zend\Ldap\Exception\LdapException
+     * @see Iterator
+     *
+     * @return void
      */
     public function next()
     {
-        $code = 0;
-
-        if (is_resource($this->current) && $this->itemCount > 0) {
-            $resource = $this->ldap->getResource();
-            ErrorHandler::start();
-            $this->current = ldap_next_entry($resource, $this->current);
-            ErrorHandler::stop();
-            if ($this->current === false) {
-                $msg = $this->ldap->getLastError($code);
-                if ($code === Exception\LdapException::LDAP_SIZELIMIT_EXCEEDED) {
-                    // we have reached the size limit enforced by the server
-                    return;
-                } elseif ($code > Exception\LdapException::LDAP_SUCCESS) {
-                    throw new Exception\LdapException($this->ldap, 'getting next entry (' . $msg . ')');
-                }
-            }
-        } else {
-            $this->current = false;
-        }
+        next($this->entries);
+        $nextEntry = current($this->entries);
+        $this->current = $nextEntry['resource'];
     }
 
     /**
      * Rewind the Iterator to the first result item
-     * Implements Iterator
      *
+     * @see Iterator
      *
-     * @throws \Zend\Ldap\Exception\LdapException
+     * @return void
      */
     public function rewind()
     {
-        if (is_resource($this->resultId)) {
-            $resource = $this->ldap->getResource();
-            ErrorHandler::start();
-            $this->current = ldap_first_entry($resource, $this->resultId);
-            ErrorHandler::stop();
-            if ($this->current === false
-                && $this->ldap->getLastErrorCode() > Exception\LdapException::LDAP_SUCCESS
-            ) {
-                throw new Exception\LdapException($this->ldap, 'getting first entry');
-            }
-        }
+        reset($this->entries);
+        $nextEntry = current($this->entries);
+        $this->current = $nextEntry['resource'];
     }
 
     /**
@@ -335,5 +351,61 @@ class DefaultIterator implements Iterator, Countable
     public function valid()
     {
         return (is_resource($this->current));
+    }
+
+    /**
+     * Set a sorting-algorithm for this iterator
+     *
+     * The callable has to accept two parameters that will be compared.
+     *
+     * @param callable $sortingAlgorithm The algorithm to be used for sorting
+     *
+     * @return DefaultIterator Provides a fluent interface
+     */
+    public function setSortFunction(callable $sortFunction)
+    {
+        $this->sortFunction = $sortFunction;
+
+        return $this;
+    }
+
+    /**
+     * Sort the iterator
+     *
+     * Sorting is done using the set sortFunction which is by default strnatcasecmp.
+     *
+     * The attribute is determined by lowercasing everything.
+     *
+     * The sort-value will be the first value of the attribute.
+     *
+     * @param string $sortAttribute The attribute to sort by. If not given the
+     *                              value set via setSortAttribute is used.
+     *
+     * @return void
+     */
+    public function sort($sortAttribute)
+    {
+        foreach ($this->entries as $key => $entry) {
+            $attributes = ldap_get_attributes(
+                $this->ldap->getResource(),
+                $entry['resource']
+            );
+
+            $attributes = array_change_key_case($attributes, CASE_LOWER);
+
+            if (isset($attributes[$sortAttribute][0])) {
+                $this->entries[$key]['sortValue'] =
+                    $attributes[$sortAttribute][0];
+            }
+        }
+
+        $sortFunction = $this->sortFunction;
+        $sorted = usort($this->entries, function ($a, $b) use ($sortFunction) {
+            return $sortFunction($a['sortValue'], $b['sortValue']);
+        });
+
+        if (! $sorted) {
+            throw new Exception\LdapException($this, 'sorting result-set');
+        }
     }
 }

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -923,16 +923,12 @@ class Ldap
         if ($search === false) {
             throw new Exception\LdapException($this, 'searching: ' . $filter);
         }
-        if ($sort !== null && is_string($sort)) {
-            ErrorHandler::start(E_WARNING);
-            $isSorted = ldap_sort($resource, $search, $sort);
-            ErrorHandler::stop();
-            if ($isSorted === false) {
-                throw new Exception\LdapException($this, 'sorting: ' . $sort);
-            }
-        }
 
         $iterator = new Collection\DefaultIterator($this, $search);
+
+        if ($sort !== null && is_string($sort)) {
+            $iterator->sort($sort);
+        }
 
         return $this->createCollection($iterator, $collectionClass);
     }

--- a/test/SortTest.php
+++ b/test/SortTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\Ldap;
+
+use Zend\Ldap\Collection\DefaultIterator;
+
+class SortTest extends AbstractOnlineTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->prepareLDAPServer();
+    }
+
+    protected function tearDown()
+    {
+        $this->cleanupLDAPServer();
+        parent::tearDown();
+    }
+
+    /**
+     * Test whether a callable is set correctly
+     */
+    public function testSettingCallable()
+    {
+        $search = ldap_search(
+            $this->getLDAP()->getResource(),
+            getenv('TESTS_ZEND_LDAP_WRITEABLE_SUBTREE'),
+            '(l=*)',
+            ['l']
+        );
+
+        $iterator = new DefaultIterator($this->getLdap(), $search);
+        $sortFunction = function ($a, $b) {
+            return 1;
+        };
+
+        $this->assertAttributeEquals('strnatcasecmp', 'sortFunction', $iterator);
+        $iterator->setSortFunction($sortFunction);
+        $this->assertAttributeEquals($sortFunction, 'sortFunction', $iterator);
+    }
+
+    /**
+     * Test whether sorting works as expected out of the box
+     */
+    public function testSorting()
+    {
+        $lSorted = ['a', 'b', 'c', 'd', 'e'];
+
+        $search = ldap_search(
+            $this->getLDAP()->getResource(),
+            getenv('TESTS_ZEND_LDAP_WRITEABLE_SUBTREE'),
+            '(l=*)',
+            ['l']
+        );
+
+        $iterator = new DefaultIterator($this->getLdap(), $search);
+
+        $this->assertAttributeEquals('strnatcasecmp', 'sortFunction', $iterator);
+        $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('entries');
+        $reflectionProperty->setAccessible(true);
+        $reflectionEntries = $reflectionProperty->getValue($iterator);
+
+        $iterator->sort('l');
+
+        $this->assertAttributeEquals([
+            [
+                'resource' => $reflectionEntries[4]['resource'],
+                'sortValue' => 'a',
+            ], [
+                'resource' => $reflectionEntries[3]['resource'],
+                'sortValue' => 'b',
+            ], [
+                'resource' => $reflectionEntries[2]['resource'],
+                'sortValue' => 'c',
+            ], [
+                'resource' => $reflectionEntries[1]['resource'],
+                'sortValue' => 'd',
+            ], [
+                'resource' => $reflectionEntries[0]['resource'],
+                'sortValue' => 'e',
+            ],
+        ], 'entries', $iterator);
+    }
+
+    /**
+     * Test sorting with custom sort-function
+     */
+    public function testCustomSorting()
+    {
+        $lSorted = ['a', 'b', 'c', 'd', 'e'];
+
+        $search = ldap_search(
+            $this->getLDAP()->getResource(),
+            getenv('TESTS_ZEND_LDAP_WRITEABLE_SUBTREE'),
+            '(l=*)',
+            ['l']
+        );
+
+        $iterator = new DefaultIterator($this->getLdap(), $search);
+        $sortFunction = function ($a, $b) use ($lSorted) {
+            if (array_search($a, $lSorted) % 2 === 0) {
+                return -1;
+            }
+
+            return 1;
+        };
+        $iterator->setSortFunction($sortFunction);
+
+        $this->assertAttributeEquals($sortFunction, 'sortFunction', $iterator);
+        $reflectionObject = new \ReflectionObject($iterator);
+        $reflectionProperty = $reflectionObject->getProperty('entries');
+        $reflectionProperty->setAccessible(true);
+        $reflectionEntries = $reflectionProperty->getValue($iterator);
+
+        $iterator->sort('l');
+
+        $this->assertAttributeEquals([
+            [
+                'resource' => $reflectionEntries[4]['resource'],
+                'sortValue' => 'a',
+            ], [
+                'resource' => $reflectionEntries[0]['resource'],
+                'sortValue' => 'e',
+            ], [
+                'resource' => $reflectionEntries[2]['resource'],
+                'sortValue' => 'c',
+            ], [
+                'resource' => $reflectionEntries[3]['resource'],
+                'sortValue' => 'b',
+            ], [
+                'resource' => $reflectionEntries[1]['resource'],
+                'sortValue' => 'd',
+            ],
+        ], 'entries', $iterator);
+    }
+}


### PR DESCRIPTION
This PR removes the call to the now deprecated ldap_sort-function wile
still preserving the sort-functionality.

For that the DefaultIterator is replaced with a SortableIterator (which
extends the DefaultIterator) that uses natural sorting (natcasesort).

This fixes #3 