### PR TITLE
hhvm not acept removed attribute ber_identifier

### DIFF
--- a/src/Collection/DefaultIterator.php
+++ b/src/Collection/DefaultIterator.php
@@ -196,13 +196,11 @@ class DefaultIterator implements Iterator, Countable
         }
 
         $entry         = ['dn' => $this->key()];
-        $berIdentifier = null;
 
         $resource = $this->ldap->getResource();
         ErrorHandler::start();
         $name = ldap_first_attribute(
-            $resource, $this->current,
-            $berIdentifier
+            $resource, $this->current
         );
         ErrorHandler::stop();
 
@@ -237,8 +235,7 @@ class DefaultIterator implements Iterator, Countable
 
             ErrorHandler::start();
             $name = ldap_next_attribute(
-                $resource, $this->current,
-                $berIdentifier
+                $resource, $this->current
             );
             ErrorHandler::stop();
         }

--- a/src/Collection/DefaultIterator.php
+++ b/src/Collection/DefaultIterator.php
@@ -199,9 +199,7 @@ class DefaultIterator implements Iterator, Countable
 
         $resource = $this->ldap->getResource();
         ErrorHandler::start();
-        $name = ldap_first_attribute(
-            $resource, $this->current
-        );
+        $name = ldap_first_attribute($resource, $this->current);
         ErrorHandler::stop();
 
         while ($name) {
@@ -234,9 +232,7 @@ class DefaultIterator implements Iterator, Countable
             $entry[$attrName] = $data;
 
             ErrorHandler::start();
-            $name = ldap_next_attribute(
-                $resource, $this->current
-            );
+            $name = ldap_next_attribute($resource, $this->current);
             ErrorHandler::stop();
         }
         ksort($entry, SORT_LOCALE_STRING);


### PR DESCRIPTION
ber_identifier was removed from php in 5.2.4 version 
http://php.net/manual/en/function.ldap-first-attribute.php
http://docs.hhvm.com/manual/en/function.ldap-first-attribute.php