### PR TITLE
Fixes issue #19

### DIFF
--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -674,6 +674,13 @@ class Ldap
         } else {
             $useSsl = (bool) $useSsl;
         }
+
+        if ($port === 0 && $useSsl) {
+            $port = 636;
+        } elseif ( $port === 0 && ! $useSsl) {
+            $port = 389;
+        }
+
         if ($useStartTls === null) {
             $useStartTls = $this->getUseStartTls();
         } else {

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -669,16 +669,15 @@ class Ldap
         } else {
             $port = (int) $port;
         }
+
         if ($useSsl === null) {
             $useSsl = $this->getUseSsl();
         } else {
             $useSsl = (bool) $useSsl;
         }
 
-        if ($port === 0 && $useSsl) {
-            $port = 636;
-        } elseif ( $port === 0 && ! $useSsl) {
-            $port = 389;
+        if ($port === 0) {
+            $port = ($useSsl)?636:389;
         }
 
         if ($useStartTls === null) {

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -677,7 +677,7 @@ class Ldap
         }
 
         if ($port === 0) {
-            $port = ($useSsl)?636:389;
+            $port = ($useSsl) ? 636 : 389;
         }
 
         if ($useStartTls === null) {

--- a/test/ConnectTest.php
+++ b/test/ConnectTest.php
@@ -252,15 +252,6 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * This test checks whether the default ports are set correctly when no port
-     * is given in the configuration.
-     *
-     * This has been reported with issue 19 of Zend\Ldap
-     *
-     * @param string $host       The host to connect to
-     * @param bool   $ssl        Whether to use ssl or not
-     * @param strnig $connectUri The expected connectionURI
-     *
      * @see https://github.com/zendframework/zend-ldap/issues/19
      * @dataProvider connectionWithoutPortInOptionsArrayProvider
      */
@@ -271,20 +262,10 @@ class ConnectTest extends \PHPUnit_Framework_TestCase
             'useSsl' => $ssl,
         ];
 
-        try {
-            $ldap = new \Zend\Ldap\Ldap($options);
-            $ldap->connect();
+        $ldap = new Ldap\Ldap($options);
+        $ldap->connect();
 
-            $r = new \ReflectionObject($ldap);
-            $p = $r->getProperty('connectString');
-            $p->setAccessible(true);
-            $this->assertEquals(
-                $connectURI,
-                $p->getValue($ldap)
-            );
-        } catch (Exception\LdapException $e) {
-            $this->fail($e->getMessage());
-        }
+        $this->assertAttributeEquals($connectURI, 'connectString', $ldap);
     }
 
     public function connectionWithoutPortInOptionsArrayProvider()


### PR DESCRIPTION
This PR checks whether the LDAP-connection shall use SSL or not and
decides based on that which port to use if no port has been set.

This fixes issue #19 