### PR TITLE
createFilterString escape method fix

### DIFF
--- a/src/Filter.php
+++ b/src/Filter.php
@@ -211,7 +211,7 @@ class Filter extends Filter\StringFilter
         if ($prepend !== null) {
             $str .= $prepend;
         }
-        $str .= static::escapeValue($value);
+        $str .= ldap_escape($value, null, LDAP_ESCAPE_FILTER);
         if ($append !== null) {
             $str .= $append;
         }


### PR DESCRIPTION
createFilterString uses ldap_escape() instead of escapeValue() to escape filter values which fixes an issue where certain guids are not escaped correctly.
