### PR TITLE
Remove duplicated phpunit entry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "zendframework/zend-config": "^2.5",
         "zendframework/zend-eventmanager": "^2.6.3 || ^3.0.1",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
-        "phpunit/PHPUnit": "^4.5",
         "php-mock/php-mock-phpunit": "~0.3",
         "zendframework/zend-coding-standard": "~1.0.0",
         "phpunit/phpunit": "^4.6"


### PR DESCRIPTION
I just noticed that my new-coding-standard PR accidently added a second entry for phpunit.