### PR TITLE
Use Ubuntu Trusty for Travis CI runs

### DIFF
--- a/.ci/php.ini
+++ b/.ci/php.ini
@@ -1,1 +1,1 @@
-extension=ldap.so
+# extension=ldap.so

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 
+dist: trusty
 language: php
 
 branches:
@@ -74,10 +75,10 @@ matrix:
     - php: hhvm
       env:
         - DEPS=lowest
-    - php: hhvm 
+    - php: hhvm
       env:
         - DEPS=locked
-    - php: hhvm 
+    - php: hhvm
       env:
         - DEPS=latest
   allow_failures:


### PR DESCRIPTION
Use Ubuntu Trusty for Travis CI runs so the cloud and vagrant environments more closely match.