### PR TITLE
Use connection string in non-ssl case when proto is not defined in host option

### DIFF
--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -700,7 +700,6 @@ class Ldap
             throw new Exception\LdapException(null, 'A host parameter is required');
         }
 
-        $useUri = false;
         /* Because ldap_connect doesn't really try to connect, any connect error
          * will actually occur during the ldap_bind call. Therefore, we save the
          * connect string here for reporting it in error handling in bind().
@@ -708,15 +707,12 @@ class Ldap
         $hosts = [];
         if (preg_match_all('~ldap(?:i|s)?://~', $host, $hosts, PREG_SET_ORDER) > 0) {
             $this->connectString = $host;
-            $useUri              = true;
             $useSsl              = false;
         } else {
             if ($useSsl) {
                 $this->connectString = 'ldaps://' . $host;
-                $useUri              = true;
             } else {
                 $this->connectString = 'ldap://' . $host;
-                $useUri              = true;
             }
             if ($port) {
                 $this->connectString .= ':' . $port;
@@ -725,12 +721,9 @@ class Ldap
 
         $this->disconnect();
 
-
-        /* Only OpenLDAP 2.2 + supports URLs so if SSL is not requested, just
-         * use the old form.
-         */
+        // We supporting here only OpenLDAP 2.2 + which supports URLs (drop support of old-style host/port connections).
         ErrorHandler::start();
-        $resource = ($useUri) ? ldap_connect($this->connectString) : ldap_connect($host, $port);
+        $resource = ldap_connect($this->connectString);
         ErrorHandler::stop();
 
         if (is_resource($resource) === true) {

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -716,6 +716,7 @@ class Ldap
                 $useUri              = true;
             } else {
                 $this->connectString = 'ldap://' . $host;
+                $useUri              = true;
             }
             if ($port) {
                 $this->connectString .= ':' . $port;

--- a/src/Ldap.php
+++ b/src/Ldap.php
@@ -705,9 +705,10 @@ class Ldap
          * connect string here for reporting it in error handling in bind().
          */
         $hosts = [];
-        if (preg_match_all('~ldap(?:i|s)?://~', $host, $hosts, PREG_SET_ORDER) > 0) {
+        if (preg_match_all('~ldap(i|s)?://~', $host, $hosts, PREG_SET_ORDER) > 0) {
             $this->connectString = $host;
-            $useSsl              = false;
+            // assign $useSsl to true in case of ldaps schema
+            $useSsl = (isset($hosts[0][1]) && $hosts[0][1] === 's') ? true : false;
         } else {
             if ($useSsl) {
                 $this->connectString = 'ldaps://' . $host;
@@ -721,7 +722,7 @@ class Ldap
 
         $this->disconnect();
 
-        // We supporting here only OpenLDAP 2.2 + which supports URLs (drop support of old-style host/port connections).
+        // We supporting here only OpenLDAP 2.2 + which uses URLs for conections (drop support of old-style host/port connections).
         ErrorHandler::start();
         $resource = ldap_connect($this->connectString);
         ErrorHandler::stop();


### PR DESCRIPTION
For now inside connection procedure we surprisingly [generating connection string in non-ssl mode and in when proto is not specified inside *host* option](https://github.com/zendframework/zend-ldap/blob/17f8c531f95840f8a508f6b8e8dfe81775ec3d97/src/Ldap.php#L717-L718) but [never use it](https://github.com/zendframework/zend-ldap/blob/master/src/Ldap.php#L732) during factual connection which is probably wrong since we do not pass generated string (containing proto) to *ldap_connect* function.

This PR fixes this behaviour.

 